### PR TITLE
added a #include <iostream> without which the compilation fails on MacOS

### DIFF
--- a/src/ctrl-cut/cut/operations/Deonion.cpp
+++ b/src/ctrl-cut/cut/operations/Deonion.cpp
@@ -70,8 +70,8 @@ void walkTheEdge(Route& skins, UniqueSegmentGraph& graph, const Edge lastEdge, c
     if(!concat(skins, seg))
       append(skins,seg);
 
-    graph.index.erase(seg.first);
-    graph.index.erase(seg.second);
+    // graph.index.erase(seg.first);
+    // graph.index.erase(seg.second);
     walkTheEdge(skins, graph, nextEdge, get_opposite(graph, nextEdge, outV));
   }
 

--- a/src/ctrl-cut/util/Util.cpp
+++ b/src/ctrl-cut/util/Util.cpp
@@ -9,6 +9,7 @@
 #include <csignal>
 #include <set>
 #include <cstdlib>
+#include <iostream>
 
 std::set<std::string> temp_file_names;
 


### PR DESCRIPTION
- new #include, doesn't compile on MacOS without it
- commented two lines that otherwise caused a bug where some lines are not cut in special cases
