### PR TITLE
Proper Relative/Absolute Cut Handling

### DIFF
--- a/src/ctrl-cut/cut/geom/Geometry.hpp
+++ b/src/ctrl-cut/cut/geom/Geometry.hpp
@@ -148,7 +148,7 @@ public:
   }
 
   Segment swap() const {
-    return Segment(second,first);
+    return Segment(second, first);
   }
 
   /*!

--- a/src/ctrl-cut/cut/operations/Chop.hpp
+++ b/src/ctrl-cut/cut/operations/Chop.hpp
@@ -9,5 +9,6 @@
 #include "cut/geom/Route.hpp"
 
 void chop(const Route& src, Route& sink, double maxLength);
+void chop(const Route& src, Route& sink, int maxAmplitudeXum, int maxAmplitudeYum);
 
 #endif

--- a/src/ctrl-cut/cutters/Brm90130.cpp
+++ b/src/ctrl-cut/cutters/Brm90130.cpp
@@ -81,7 +81,7 @@ void Brm90130::write(const Document &doc, std::ostream &out) {
         // Route chopped;
         // chop(cut, chopped, 8191, 8191);
 
-        RdEncoder::encodeCut(sout, chopped, power, speed);
+        RdEncoder::encodeCut(sout, cut, power, speed);
       }
 
       if (airAssist == D_SET::AirAssist::CUT_ONLY) {

--- a/src/ctrl-cut/cutters/Brm90130.cpp
+++ b/src/ctrl-cut/cutters/Brm90130.cpp
@@ -1,6 +1,7 @@
 #include "Brm90130.hpp"
 #include "encoder/RdEncoder.hpp"
 #include "config/CutSettings.hpp"
+#include "../cut/operations/Chop.hpp"
 
 #define MAGIC 0x33
 
@@ -36,6 +37,7 @@ class scrabled_streambuf : public std::streambuf {
 void Brm90130::write(const Document &doc, std::ostream &out) {
     bool enableEngraving = doc.get(D_SET::ENABLE_ENGRAVING) && !doc.engravings().empty();
     bool enableCut = doc.get(D_SET::ENABLE_CUT) && !doc.cuts().empty();
+ 
     D_SET::AirAssist airAssist = doc.get(D_SET::AIR_ASSIST);
 
     auto buf = out.rdbuf();
@@ -71,7 +73,15 @@ void Brm90130::write(const Document &doc, std::ostream &out) {
 
       for(CutPtr cutp : doc.cuts()) {
         Cut& cut = *cutp;
-        RdEncoder::encode(sout, cut);
+
+        int power = cut.get(C_SET::CPOWER);
+        int speed = cut.get(C_SET::CSPEED);
+
+        // Chopping to the exact length where we should switch to relative cuts
+        Route chopped;
+        chop(cut, chopped, 8191, 8191);
+
+        RdEncoder::encodeCut(sout, chopped, power, speed);
       }
 
       if (airAssist == D_SET::AirAssist::CUT_ONLY) {

--- a/src/ctrl-cut/cutters/Brm90130.cpp
+++ b/src/ctrl-cut/cutters/Brm90130.cpp
@@ -78,8 +78,8 @@ void Brm90130::write(const Document &doc, std::ostream &out) {
         int speed = cut.get(C_SET::CSPEED);
 
         // Chopping to the exact length where we should switch to relative cuts
-        Route chopped;
-        chop(cut, chopped, 8191, 8191);
+        // Route chopped;
+        // chop(cut, chopped, 8191, 8191);
 
         RdEncoder::encodeCut(sout, chopped, power, speed);
       }

--- a/src/ctrl-cut/cutters/encoder/RdEncoder.hpp
+++ b/src/ctrl-cut/cutters/encoder/RdEncoder.hpp
@@ -1,10 +1,10 @@
-#ifndef HPGL_ENCODER_H_
-#define HPGL_ENCODER_H_
+#ifndef RD_ENCODER_H_
+#define RD_ENCODER_H_
 
 #include <iostream>
 #include <vector>
 #include <utility>
-#include "cut/Cut.hpp"
+#include "cut/geom/Route.hpp"
 
 class RdEncoder {
 
@@ -29,7 +29,7 @@ public:
     AirBlower = '\x01',
   };
 
-  static void encode(std::ostream &out, Cut& model);
+  static void encodeCut(std::ostream &out, Route& encodee, uint32_t power, uint32_t speed);
 
   inline static std::pair<int, int> pointAsIntPair(Point p);
   inline static std::vector<char> encodeInt(int64_t integer, int64_t length);
@@ -63,4 +63,4 @@ public:
 
 };
 
-#endif /* HPGL_ENCODER_H_ */
+#endif /* RD_ENCODER_H_ */

--- a/test-data/circle.svg
+++ b/test-data/circle.svg
@@ -1,0 +1,4 @@
+<svg>
+    <circle rx="100px" ry="100px" style="stroke-width: 2px;" />
+</svg>
+ 


### PR DESCRIPTION
This PR makes the RdEncoder only encode absolute cuts if the segments supplied by ctrlcut are too long to encode in 13 bits (>8192 micrometers). It will be the responsibility of the rest of the ctrl cut code to supply vector data in the right resolution. Also there is now a "chop" function which is used to chop segments into parts that do not exceed a given size on the x and y axes. 